### PR TITLE
Added functions for the remaining file-sending methods of the bot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Use `morse.api` to interact with Telegram chats:
 (require '[morse.api :as api])
 ```
 
-Following methods from the API are implemented at the moment:
+Following methods from the API are implemented at the moment. All of them may use the advanced options by providing an additional option map argument. For all functions sending files File, ByteArray and InputStream are supported as arguments.
 
 ### [`sendMessage`](https://core.telegram.org/bots/api#sendmessage)
 
@@ -116,6 +116,7 @@ You can use advanced options:
 ### [`sendPhoto`](https://core.telegram.org/bots/api#sendphoto)
 
 File, ByteArray and InputStream are supported as images for that function:
+This sends a photo that will be displayed using the embedded image viewer where available.
  
 ```clojure
 (require '[clojure.java.io :as io])
@@ -132,6 +133,33 @@ You can use advanced options:
                 (io/file (io/resource "map.png")))
 ```
  
+### [`sendVideo`](https://core.telegram.org/bots/api#sendvideo)
+
+Sends the given mp4 file as a video to the chat which will be shown using the embedded player where available.
+
+```clojure
+(api/send-video token chat-id
+                (io/file (io/resource "video.mp4")))
+```
+
+
+### [`sendAudio`](https://core.telegram.org/bots/api#sendaudio)
+
+Sends the given mp3 file as an audio message to the chat.
+
+```clojure
+(api/send-audio token chat-id
+                (io/file (io/resource "audio.mp3")))
+```
+
+### [`sendDocument`](https://core.telegram.org/bots/api#senddocument)
+
+This method can be used for any other kind of file not supported by the other methods, or if you don't want telegram to make a special handling of your file (i.e. sending music as a voice message).
+
+```clojure
+(api/send-document token chat-id
+                   (io/file (io/resource "document.pdf")))
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ You can use advanced options:
 
 ### [`sendPhoto`](https://core.telegram.org/bots/api#sendphoto)
 
-File, ByteArray and InputStream are supported as images for that function:
 This sends a photo that will be displayed using the embedded image viewer where available.
  
 ```clojure

--- a/src/morse/api.clj
+++ b/src/morse/api.clj
@@ -30,42 +30,56 @@
          resp (http/get url {:as :json :query-params query})]
      (-> resp :body))))
 
-(defn send-file 
-  ([token chat-id file method field filename] 
-   (send-file token chat-id {} file method field filename))
-  ([token chat-id options file method field filename]
-   (let [url (str base-url token method)
-         base-form [{:part-name "chat_id" :content (str chat-id)}
-                    {:part-name field :content file :name filename}]
-         options-form (for [[key value] options]
-                        {:part-name (name key) :content value})
-         form (into base-form options-form)
-         resp (http/post url {:as :json :multipart form})]
-     (-> resp :body))))
+(defn send-file [token chat-id options file method field filename]
+  "Helper function to send various kinds of files as multipart-encoded"
+  (let [url (str base-url token method)
+        base-form [{:part-name "chat_id" :content (str chat-id)}
+                   {:part-name field :content file :name filename}]
+        options-form (for [[key value] options]
+                       {:part-name (name key) :content value})
+        form (into base-form options-form)
+        resp (http/post url {:as :json :multipart form})]
+    (-> resp :body)))
 
-(defmacro accepted-formats [file valid-extensions & body]
-  "If file is an instance of java.io.File, it checks its extension is valid.
-  Only files are checked, if the file argument is not an instance of File
-  the check will be omitted." 
-  `(if (or (not= (type ~file) java.io.File) 
-           ~@(map (fn [extension] `(.endsWith (.getName ~file) ~extension)) valid-extensions))
-     (do ~@body)
-     (throw (ex-info (str "Telegram API only supports the following formats: " 
-                          ~(string/join ", " valid-extensions) 
-                          " for this method. Other formats may be sent with send-document") 
-                     {}))))
+(defn is-file? 
+  "Is value a file?" 
+  [value] (= java.io.File (type value)))
+(defn of-type? 
+  "Does the extension of file match any of the extensions in valid-extensions?"
+  [file valid-extensions] (some #(.endsWith (.getName file) %) valid-extensions))
+(defn assert-file-type 
+  "Throws if value is a file but it's extension is not valid."
+  [value valid-extensions]
+  (when (and (is-file? value)
+             (not (of-type? valid-extensions)))
+    (throw (ex-info (str "Telegram API only supports the following formats: " 
+                         (string/join ", " valid-extensions) 
+                         " for this method. Other formats may be sent using send-document") 
+                    {}))))
 
-(defn send-photo [token chat-id image]
-  (accepted-formats image ["jpg" "jpeg" "gif" "png" "tif" "bmp"] 
-    (send-file token chat-id image "/sendPhoto" "photo" "photo.png")))
+(defn send-photo 
+  "Sends an image to the chat"
+  ([token chat-id image] (send-photo token chat-id {} image))
+  ([token chat-id options image] 
+   (assert-file-type image ["jpg" "jpeg" "gif" "png" "tif" "bmp"]) 
+   (send-file token chat-id options image "/sendPhoto" "photo" "photo.png")))
 
-(defn send-document [token chat-id document]
-  (send-file token chat-id document "/sendDocument" "document" "document"))
+(defn send-document 
+  "Sends a document to the chat"
+  ([token chat-id document] (send-document token chat-id {} document))
+  ([token chat-id options document]
+   (send-file token chat-id options document "/sendDocument" "document" "document")))
 
-(defn send-video [token chat-id video]
-  (accepted-formats video ["mp4"] 
-    (send-file token chat-id video "/sendVideo" "video" "video.mp4")))
+(defn send-video 
+  "Sends a video to the chat"
+  ([token chat-id video] (send-video token chat-id {} video))
+  ([token chat-id options video]
+   (assert-file-type video ["mp4"]) 
+   (send-file token chat-id options video "/sendVideo" "video" "video.mp4")))
 
-(defn send-audio [token chat-id audio]
-  (accepted-formats audio ["mp3"] 
-    (send-file token chat-id audio "/sendAudio" "audio" "audio.mp3")))
+(defn send-audio 
+  "Sends an audio message to the chat"
+  ([token chat-id audio] (send-audio token chat-id {} audio))
+  ([token chat-id options audio]
+   (assert-file-type audio ["mp3"]) 
+   (send-file token chat-id options audio "/sendAudio" "audio" "audio.mp3")))

--- a/src/morse/api.clj
+++ b/src/morse/api.clj
@@ -43,10 +43,17 @@
          resp (http/post url {:as :json :multipart form})]
      (-> resp :body))))
 
-(defmacro accepted-formats [file extensions & body]
-  `(if ~(conj (map (fn [extension] `(.endsWith (.getName ~file) ~extension)) extensions) `or)
+(defmacro accepted-formats [file valid-extensions & body]
+  "If file is an instance of java.io.File, it checks its extension is valid.
+  Only files are checked, if the file argument is not an instance of File
+  the check will be omitted." 
+  `(if (or (not= (type ~file) java.io.File) 
+           ~@(map (fn [extension] `(.endsWith (.getName ~file) ~extension)) valid-extensions))
      (do ~@body)
-     (throw (ex-info (str "Telegram API only supports the following formats: " ~(string/join ", " extensions) " for this method. Other formats may be sent with send-document") {}))))
+     (throw (ex-info (str "Telegram API only supports the following formats: " 
+                          ~(string/join ", " valid-extensions) 
+                          " for this method. Other formats may be sent with send-document") 
+                     {}))))
 
 (defn send-photo [token chat-id image]
   (accepted-formats image ["jpg" "jpeg" "gif" "png" "tif" "bmp"] 


### PR DESCRIPTION
Changed send-photo into a more generic function send-file and then created the wrappers for the methods: sendDocument sendVideo and sendAudio  that were missing. Also added a macro "accepted-formats" to avoid repetition of code which allows to check wether the file to be sent has the correct format for the metod (and thus avoiding needlesly calling the API).