### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ object from Telegram as a Clojure map. Morse provides some helpers for you:
   (command "start" {user :user} (println "User" user "joined"))
   (command "chroma" message (handle-text message))
 
-  (mesage message (println "Intercepted message:" message)))
+  (message message (println "Intercepted message:" message)))
 ```
 
 There are two possible helpers for messages:

--- a/src/morse/handlers.clj
+++ b/src/morse/handlers.clj
@@ -69,7 +69,7 @@
     (command "start" {user :user} (println "User" user "joined"))
     (command "chroma" message (handle-text message))
 
-    (mesage message (println "Intercepted message:" message))
+    (message message (println "Intercepted message:" message))
 
     (inline {user :from q :query} (println "User" user "made inline query" q)))
 


### PR DESCRIPTION
There was a few small typos in the README and example comments for "message" in the handler. This patchset should fix that.