### PR TITLE
Do not deref a string when setting a webhook

### DIFF
--- a/src/morse/api.clj
+++ b/src/morse/api.clj
@@ -21,7 +21,7 @@
 (defn set-webhook
   "Register WebHook to receive updates from chats"
   [token webhook-url]
-  (let [url   (str base-url @token "/setWebhook")
+  (let [url   (str base-url token "/setWebhook")
         query {:url webhook-url}]
     (http/get url {:as :json :query-params query})))
 


### PR DESCRIPTION
As far as I can tell, `token` should be string as it's a string everywhere else.