### PR TITLE
sendMessage should be using POST for dealing with nested options

### DIFF
--- a/src/morse/api.clj
+++ b/src/morse/api.clj
@@ -31,8 +31,10 @@
   ([token chat-id text] (send-text token chat-id {} text))
   ([token chat-id options text]
    (let [url (str base-url token "/sendMessage")
-         query (into {:chat_id chat-id :text text} options)
-         resp (http/get url {:as :json :query-params query})]
+         body (into {:chat_id chat-id :text text} options)
+         resp (http/post url {:content-type :json
+                              :as :json
+                              :form-params body})]
      (-> resp :body))))
 
 


### PR DESCRIPTION
`sendMessage` with query params is not enough for dealing with complicated-nested options like replyMarkup.

Reference, https://core.telegram.org/bots/api#inlinekeyboardmarkup
