### PR TITLE
Allow to understand commands ending with '@'

### DIFF
--- a/src/morse/handlers.clj
+++ b/src/morse/handlers.clj
@@ -32,6 +32,8 @@
           :text
           (s/split #"\s+")
           (first)
+          (s/split #"@")
+          (first)
           (= (str "/" name))))
 
 


### PR DESCRIPTION
Split and ignore part of a command goes by '@' symbol