### PR TITLE
catch Throwable instead of Exception if handling update in go-loop fails

### DIFF
--- a/src/morse/polling.clj
+++ b/src/morse/polling.clj
@@ -43,8 +43,8 @@
     (when-let [data (<! updates)]
       (try
         (handler data)
-        (catch Exception e
-          (log/error e "Unable to handle update" data)))
+        (catch Throwable t
+          (log/error t "Unable to handle update" data)))
       (recur))))
 
 


### PR DESCRIPTION
AssertionErrors don't subclass Exception so they will kill the loop :)