### PR TITLE
Upgrade core.async to be Clojure 1.9 compatible

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  [org.clojure/tools.macro "0.1.5"]
-                 [org.clojure/core.async "0.2.374"]
+                 [org.clojure/core.async "0.3.465"]
                  [org.clojure/tools.logging "0.3.1"]
                  [clj-stacktrace "0.2.8"]
                  [cheshire "5.5.0"]


### PR DESCRIPTION
Versions of core.async older than 0.3.442 are broken with Clojure 1.9-alpha15 and newer. Morse itself seems to work fine, this is just to make the dependencies work out of the box.

Meanwhile, if somebody is getting a spec exception about `:refer-clojure` when loading Morse, try adding `[org.clojure/core.async "0.3.465"]` as a dependency to your project.