### PR TITLE
Using async http requests for get-updates and polling;

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,10 +9,10 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [clj-stacktrace "0.2.8"]
                  [cheshire "5.5.0"]
-                 [clj-http "2.1.0"]]
+                 [clj-http "3.7.0"]]
 
   :profiles {:uberjar {:aot :all}
-             :test    {:dependencies [[clj-http-fake "1.0.2"]]
+             :test    {:dependencies [[clj-http-fake "1.0.3"]]
                        :plugins      [[pjstadig/humane-test-output "0.8.2"]
                                       [com.jakemccrary/lein-test-refresh "0.14.0"]
                                       [com.taoensso/timbre "4.1.4"]]}}

--- a/src/morse/api.clj
+++ b/src/morse/api.clj
@@ -10,22 +10,17 @@
 
 (defn get-updates
   "Receive updates from Bot via long-polling endpoint"
-  [token {:keys [limit offset timeout]}]
-  (let [url      (str base-url token "/getUpdates")
-        query    {:timeout (or timeout 1)
-                  :offset  (or offset 0)
-                  :limit   (or limit 100)}
-        response (http/get url {:as               :json
-                                :query-params     query
-                                :throw-exceptions false})
-        {:keys [status body]} response]
-    (if (< status 300)
-      (:result body)
-
-      (do
-        (log/error "Telegram returned" (:status response)
-                   "from /getUpdates:" (:body response))
-        ::error))))
+  ([token resp-handler err-handler {:keys [limit offset timeout]}]
+   (let [url      (str base-url token "/getUpdates")
+         query    {:timeout (or timeout 1)
+                   :offset  (or offset 0)
+                   :limit   (or limit 100)}
+         request {:as               :json
+                  :query-params     query
+                  :async?           true}]
+     (http/get url request #(resp-handler (-> %
+                                              :body
+                                              :result)) err-handler))))
 
 
 (defn set-webhook

--- a/test/morse/api_test.clj
+++ b/test/morse/api_test.clj
@@ -81,25 +81,24 @@
 
 (deftest get-updates-request
   (is (= #{"timeout=1" "offset=0" "limit=100"}
-         (-> (api/get-updates token {})
+         (-> (api/get-updates token identity identity {})
              (u/capture-request)
              (u/extract-query-set))))
 
   (is (= #{"timeout=1" "offset=0" "limit=200"}
-         (-> (api/get-updates token {:limit 200})
+         (-> (api/get-updates token identity identity {:limit 200})
              (u/capture-request)
              (u/extract-query-set))))
 
   (is (= #{"timeout=1" "offset=31337" "limit=100"}
-         (-> (api/get-updates token {:offset 31337})
+         (-> (api/get-updates token identity identity {:offset 31337})
              (u/capture-request)
              (u/extract-query-set))))
 
   (testing "method returns part of the reponse body"
     (let [updates {:foo "bar"}]
       (u/with-faked-updates updates
-        (is (= updates
-               (api/get-updates token {})))))))
+        (is (= updates (api/get-updates token identity identity {})))))))
 
 (deftest answer-inline-request
   (let [req (-> (api/answer-inline token inline-query-id

--- a/test/morse/polling_test.clj
+++ b/test/morse/polling_test.clj
@@ -4,18 +4,35 @@
             [morse.polling :as poll]
             [morse.test-utils :as u]))
 
-(def sample-update {:update_id 0
-                    :message {:text "foo"
-                              :chat {:id "bar"}}})
+(def sample-update [{:update_id 0
+                     :message {:text "foo"
+                               :chat {:id "bar"}}}])
 
 (defn handler-for [channel]
-  (fn [upd] (go (>! channel upd))))
+  (fn [upd]
+    (go (>! channel upd))))
 
 (deftest handler-receives-update
-  (u/with-faked-updates [sample-update]
+  (testing "passing the response from updates function correctly"
     (let [result  (chan)
           handler (handler-for result)
-          running (poll/start "token" handler)]
-      (is (= sample-update (<!! result)))
-      (poll/stop running))))
+          running (poll/start "token" handler
+                              {:get-updates-fn
+                               (fn [_ resp-handler _ _]
+                                 (go (resp-handler sample-update)))})]
+      (is (= (first sample-update) (<!! result)))
+      (poll/stop running)))
 
+  (testing "stopping polling process when exception happens"
+    (let [running (poll/start "token" identity
+                              {:get-updates-fn
+                               (fn [_ _ err-handler _]
+                                 (go (err-handler (ex-info "should raise" {}))))})]
+      (is (nil? (<!! running)))))
+
+  (testing "stopping polling process when reaching global timeout"
+    (let [running (poll/start "token" identity
+                              {:wait-timeout 1
+                               :get-updates-fn
+                               (fn [_ _ _ _] :pass)})]
+      (is (nil? (<!! running))))))


### PR DESCRIPTION
- Adding global timeout outside of the API call implementation;
- Stopping polling in case of any issue - delegating retry logic to the application;

Overall this changeset tries to consolidate all potential errors that could happen during the polling process and delegate their handling to a user application (maybe I am missing some potential use-cases for a library-level retry and circuit-breaking logic).
The way tests are handled can be improved if [this issue](https://github.com/myfreeweb/clj-http-fake/issues/40) gets resolved.