### PR TITLE
Fix example usage of message macro in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ there is also a helper:
 ```clojure
 (message-fn (fn [msg] (println "Received message: " msg)))
 ; or in a macro form
-(message "start" msg (println "Received message: " msg))
+(message msg (println "Received message: " msg))
 ```
 
 ### Inline requests


### PR DESCRIPTION
When looking through the README I was confused to see the usage of the `message` macro taking a `"start"` argument. After looking closer at the source (https://github.com/Otann/morse/blob/master/src/morse/handlers.clj#L64 and https://github.com/Otann/morse/blob/master/src/morse/handlers.clj#L107-L109), it seems to be unnecessary.

Anyway, thanks for the great library, I'm planning to give it a try.