### PR TITLE
Allow to delete webhook

### DIFF
--- a/src/morse/api.clj
+++ b/src/morse/api.clj
@@ -40,6 +40,11 @@
         query {:url webhook-url}]
     (http/get url {:as :json :query-params query})))
 
+(defn delete-webhook
+  "Removes WebHook to stop receiving updates from chats"
+  [token]
+  (let [url (str base-url token "/deleteWebhook")]
+    (http/get url {:as :json})))
 
 (defn get-file
   "Gets url of the file"


### PR DESCRIPTION
Sometimes it might be useful to change the webhook. Unfortunately, there's no
other way to change it once it has been configured so we need to delete the webhook
and set it again.
This commit will add the missing functionality.