### PR TITLE
Fix warnings on unnecessary reflection calls

### DIFF
--- a/src/morse/api.clj
+++ b/src/morse/api.clj
@@ -133,7 +133,7 @@
 (defn of-type?
   "Does the extension of file match any of the
   extensions in valid-extensions?"
-  [file valid-extensions]
+  [^File file valid-extensions]
   (some #(-> file .getName (.endsWith %))
         valid-extensions))
 


### PR DESCRIPTION
Add an explicit type hint in order to avoid unnecessary reflective calls:
 - Reflection warning, morse/api.clj:137:28 - reference to field getName can't be resolved.
 - Reflection warning, morse/api.clj:137:28 - call to method endsWith can't be resolved (target class is unknown).