### PR TITLE
Adjust docs regarding Compojure

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,15 @@ You can also use handler to react on these messages.
 Here is quick example if you use [`compojure`](https://github.com/weavejester/compojure):
 
 ```clojure
+(require '[compojure.core :refer [GET POST defroutes]]
+         '[compojure.route :as route])
+
 (defhandler bot-api
   (command "help" {{id :id} :chat}
     (api/send-text token id "Help is on the way")))
 
 (defroutes app-routes
-  (POST "/handler" {{updates :result} :body} (map bot-api updates))
+  (POST "/handler" {body :body} (bot-api body))
   (route/not-found "Not Found"))
 ```
 


### PR DESCRIPTION
Hi 🖖

Thanks for the library! I wanted to host on a preemptible server, I wanted to use the `/setWebhook` method. I've read through README and found out I could use `compojure` with a Ring-compatible server (`http-kit` in my case). Since I'm a newcomer to Clojure, it took me a long time to figure out:
- Telegram `Update` [doesn't have a `:result` field](https://core.telegram.org/bots/api#update), or maybe doesn't have anymore 🤷‍♂️
- The handler expects the whole `Update` object
- The incoming message is expected to be json-parsed and keywordized (should I also mention that in the README?)
- There not many easily findable examples of using `morse` with `compojure`

So I decided to return to the community and update the README.

Cheers,
Olzhas
